### PR TITLE
Pin Sphinx version temporarily

### DIFF
--- a/.sphinx/requirements.txt
+++ b/.sphinx/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx==7.1.2
 sphinx-autobuild
 sphinx-design
 furo


### PR DESCRIPTION
The latest Sphinx update has caused some issues.

7.2.2 doesn't work with the `notfound` extension (see readthedocs/sphinx-notfound-page#219 ). When restricting Sphinx to <7.2.0, RTD uses 6.2.1 though, which is incompatible with a Furo change (see pradyunsg/furo#693 ).

Therefore, restrict Sphinx to 7.1.2 until the issues are resolved.